### PR TITLE
👷 ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+run-name: "Deploy to GitHub Pages by @${{ github.actor }}"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/graphql-markdown/demo-astro-starlight/tree/main)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/graphql-markdown/demo-astro-starlight/tree/main)
 
+**Live demo:** [graphql-markdown.dev/demo-astro-starlight](https://graphql-markdown.dev/demo-astro-starlight/)
+
 ## 🚀 Project Structure
 
 Inside your GraphQL-Markdown + Astro/Starlight project, you'll see the following folders and files:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` (`workflow_dispatch`, main-only)
- Installs Node.js 22, runs `npm ci` (postinstall generates docs), then `astro build`
- Deploys `./dist` to `gh-pages` via `peaceiris/actions-gh-pages`
- Adds live demo link to README

## Setup required

**Settings → Pages → Source → Deploy from a branch → `gh-pages` / `/(root)`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)